### PR TITLE
When providing browserEndpoint option, pagedJS correctly connects to it

### DIFF
--- a/bin/paged
+++ b/bin/paged
@@ -39,7 +39,7 @@ program
           "added to the HTML document before rendering. This is useful for " +
           "adding custom pagedjs handlers. The option can be repeated.",
           collect, [])
-  .option("--browserEndpoint", "Use a remote Chrome server with browserWSEndpoint")
+  .option("--browserEndpoint <browserEndpoint>", "Use a remote Chrome server with browserWSEndpoint")
   .parse(process.argv);
 
 function collect(value, previous) {
@@ -115,6 +115,7 @@ if (typeof input === "string") {
     allowedPaths: program.allowedPaths,
     allowedDomains: program.allowedDomains,
     additionalScripts: program.additionalScript,
+    browserEndpoint: program.browserEndpoint
   };
 
   if (program.forceTransparentBackground) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -3,6 +3,7 @@ const puppeteer = require("puppeteer");
 const fetch = require("node-fetch");
 
 const path = require("path");
+const fs = require("fs");
 
 let dir = process.cwd();
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -43,13 +43,12 @@ class Printer extends EventEmitter {
 
     if (this.browserWSEndpoint) {
       puppeteerOptions.browserWSEndpoint = this.browserWSEndpoint;
+      this.browser = await puppeteer.connect(puppeteerOptions);
+    } else {
+      this.browser = await puppeteer.launch(puppeteerOptions);
     }
 
-    const browser = await puppeteer.launch(puppeteerOptions);
-
-    this.browser = browser;
-
-    return browser;
+    return this.browser;
   }
 
   async render(input) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -74,7 +74,12 @@ class Printer extends EventEmitter {
         url = input;
       } catch (error) {
         relativePath = path.resolve(dir, input);
-        url = "file://" + relativePath;
+
+        if (this.browserWSEndpoint) {
+          html = fs.readFileSync(relativePath, 'utf-8')
+        } else {
+          url = "file://" + relativePath;
+        }
       }
     } else {
       url = input.url;


### PR DESCRIPTION
Issue https://gitlab.pagedmedia.org/tools/pagedjs-cli/issues/42.

1. Passing `browserEndpoint` from command line args to Printer
2. If the browser is remote, don't send an HTML file to it, but its content.
3. If browser is remote, use `puppeteer.connect` instead of `puppeteer.launch`